### PR TITLE
Delete unused method `UIKitLocalizedString()`

### DIFF
--- a/XCDFormInputAccessoryView/XCDFormInputAccessoryView.m
+++ b/XCDFormInputAccessoryView/XCDFormInputAccessoryView.m
@@ -7,12 +7,6 @@
 
 #import "XCDFormInputAccessoryView.h"
 
-static NSString * UIKitLocalizedString(NSString *string)
-{
-	NSBundle *UIKitBundle = [NSBundle bundleForClass:[UIApplication class]];
-	return UIKitBundle ? [UIKitBundle localizedStringForKey:string value:string table:nil] : string;
-}
-
 static NSArray * EditableTextInputsInView(UIView *view)
 {
 	NSMutableArray *textInputs = [NSMutableArray new];


### PR DESCRIPTION
The project is using `previous arrow image` and `back arrow image`, so the `UIKitLocalizedString()` method is unneccessary now. 
